### PR TITLE
refactor(api): change api structure for `login` and `signup` endpoints

### DIFF
--- a/backend/api/serializer.py
+++ b/backend/api/serializer.py
@@ -1,7 +1,0 @@
-from rest_framework import serializers
-from user.models import User
-
-class UserSerializer(serializers.ModelSerializer):
-    class Meta(object):
-        model = User
-        fields = '__all__'

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -16,9 +16,6 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    # path('test_token', views.test_token, name="test_token"),
-    # path('signup', views.register, name="signup"),
-    # path('login', views.login, name="login"),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('search/', views.search, name="search"),
     path('users/', include('user.urls')),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, include
 from . import views
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -17,8 +17,9 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     # path('test_token', views.test_token, name="test_token"),
-    path('signup', views.register, name="signup"),
-    path('login', views.login, name="login"),
+    # path('signup', views.register, name="signup"),
+    # path('login', views.login, name="login"),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('search/', views.search, name="search"),
+    path('users/', include('user.urls')),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,92 +1,13 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
-from user.models import User
-from .serializer import UserSerializer
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 import requests
 
-@swagger_auto_schema(
-    method='post',
-    operation_description="Register a user with a unique username, a unique email, a password and full name.",
-    operation_summary="register a user",
-    request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'username': openapi.Schema(type=openapi.TYPE_STRING),
-            'email': openapi.Schema(type=openapi.TYPE_STRING),
-            'password': openapi.Schema(type=openapi.TYPE_STRING),
-            'fullname': openapi.Schema(type=openapi.TYPE_STRING) 
-        },
-        required=['username', 'email', 'password', 'fullname']
-    ),    responses={
-        201: "Created",
-        400: "Missing required fields or nonunique username/email"
-    },
-    operation_id='signup',
-)
-@api_view(['POST'])
-def register(request):
-    required_fields = ['username', 'password', 'email', 'fullname']
-    if not all([field in request.data for field in required_fields]):
-        return Response({"error":"Please provide all required fields."}, status=status.HTTP_400_BAD_REQUEST)
-    
-    serializer = UserSerializer(data=request.data)
-    if serializer.is_valid():
-        serializer.save()
-        user = User.objects.get(username=request.data['username'])
-        user.set_password(request.data['password'])
-        user.save()
-        token = Token.objects.create(user=user)
-        return Response({"token": token.key, "user": serializer.data}, status=status.HTTP_201_CREATED)
-    
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-@swagger_auto_schema(
-    method='post',
-    operation_description="Login with a username and a password.",
-    operation_summary="login",
-    request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'username': openapi.Schema(type=openapi.TYPE_STRING),
-            'password': openapi.Schema(type=openapi.TYPE_STRING)    
-        },
-        required=['username', 'password']
-    ),
-
-    responses={
-        200: "Success",
-        400: "Missing required fields",
-        401: "Unauthorized, wrong username or password"
-    },
-    operation_id='login'
-)
-@api_view(['POST'])
-def login(request):
-    required_fields = ['username', 'password']
-    if not all([field in request.data for field in required_fields]):
-        return Response({"error":"Please provide both username and password."}, status=status.HTTP_400_BAD_REQUEST)
-
-    try:
-        user = User.objects.get(username=request.data['username'])
-    except User.DoesNotExist:
-        return Response({"error": "Username not found."}, status=status.HTTP_401_UNAUTHORIZED)
-
-    if not user.check_password(request.data['password']):
-        return Response({"error":"password does not match."}, status=status.HTTP_401_UNAUTHORIZED)
-    token, created = Token.objects.get_or_create(user=user)
-    serializer = UserSerializer(instance=user)
-    return Response({"token": token.key, "user": serializer.data}, status=status.HTTP_200_OK)
-
-
-#@api_view(['GET'])
-#def test_token(request):
-#    return Response({"error":"Token is valid!"})
 my_dict = {
     "born in new york": "Q60",
     "born in new jersey": "Q1408",

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -19,5 +19,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('user/', include('api.urls')),
+    path('api/v1/', include('api.urls')),
 ]

--- a/backend/user/serializer.py
+++ b/backend/user/serializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import User
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = User
+        fields = '__all__'

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('signup', views.register, name="signup"),
+    path('login', views.login, name="login"),
+]

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -1,3 +1,83 @@
-from django.shortcuts import render
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+from .models import User
+from .serializer import UserSerializer
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 # Create your views here.
+@swagger_auto_schema(
+    method='post',
+    operation_description="Register a user with a unique username, a unique email, a password and full name.",
+    operation_summary="register a user",
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'username': openapi.Schema(type=openapi.TYPE_STRING),
+            'email': openapi.Schema(type=openapi.TYPE_STRING),
+            'password': openapi.Schema(type=openapi.TYPE_STRING),
+            'fullname': openapi.Schema(type=openapi.TYPE_STRING) 
+        },
+        required=['username', 'email', 'password', 'fullname']
+    ),    responses={
+        201: "Created",
+        400: "Missing required fields or nonunique username/email"
+    },
+    operation_id='signup',
+)
+@api_view(['POST'])
+def register(request):
+    required_fields = ['username', 'password', 'email', 'fullname']
+    if not all([field in request.data for field in required_fields]):
+        return Response({"error":"Please provide all required fields."}, status=status.HTTP_400_BAD_REQUEST)
+    
+    serializer = UserSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        user = User.objects.get(username=request.data['username'])
+        user.set_password(request.data['password'])
+        user.save()
+        token = Token.objects.create(user=user)
+        return Response({"token": token.key, "user": serializer.data}, status=status.HTTP_201_CREATED)
+    
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@swagger_auto_schema(
+    method='post',
+    operation_description="Login with a username and a password.",
+    operation_summary="login",
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'username': openapi.Schema(type=openapi.TYPE_STRING),
+            'password': openapi.Schema(type=openapi.TYPE_STRING)    
+        },
+        required=['username', 'password']
+    ),
+
+    responses={
+        200: "Success",
+        400: "Missing required fields",
+        401: "Unauthorized, wrong username or password"
+    },
+    operation_id='login'
+)
+@api_view(['POST'])
+def login(request):
+    required_fields = ['username', 'password']
+    if not all([field in request.data for field in required_fields]):
+        return Response({"error":"Please provide both username and password."}, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        user = User.objects.get(username=request.data['username'])
+    except User.DoesNotExist:
+        return Response({"error": "Username not found."}, status=status.HTTP_401_UNAUTHORIZED)
+
+    if not user.check_password(request.data['password']):
+        return Response({"error":"password does not match."}, status=status.HTTP_401_UNAUTHORIZED)
+    token, created = Token.objects.get_or_create(user=user)
+    serializer = UserSerializer(instance=user)
+    return Response({"token": token.key, "user": serializer.data}, status=status.HTTP_200_OK)

--- a/bruno/login.bru
+++ b/bruno/login.bru
@@ -5,15 +5,15 @@ meta {
 }
 
 post {
-  url: {{base_url}}:{{port}}/user/login
+  url: {{base_url}}:{{port}}/api/v1/users/login
   body: json
   auth: none
 }
 
 body:json {
   {
-    "username": "username17",
-    "password": "pass17",
+    "username": "username2",
+    "password": "pass2",
     "keep": "on"
   }
 }

--- a/bruno/search.bru
+++ b/bruno/search.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{base_url}}:{{port}}/user/search/
+  url: {{base_url}}:{{port}}/api/v1/search/
   body: json
   auth: none
 }

--- a/bruno/signup.bru
+++ b/bruno/signup.bru
@@ -5,16 +5,16 @@ meta {
 }
 
 post {
-  url: {{base_url}}:{{port}}/user/signup
+  url: {{base_url}}:{{port}}/api/v1/users/signup
   body: json
   auth: none
 }
 
 body:json {
   {
-    "username": "username1",
-    "email": "user1@email.com",
-    "password": "pass1",
-    "fullname":"Username1"
+    "username": "username3",
+    "email": "user3@email.com",
+    "password": "pass3",
+    "fullname":"Username3"
   }
 }

--- a/bruno/swagger.bru
+++ b/bruno/swagger.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{base_url}}:{{port}}/api/v1/swagger
+  url: {{base_url}}:{{port}}/api/v1/swagger/
   body: none
   auth: none
 }

--- a/bruno/swagger.bru
+++ b/bruno/swagger.bru
@@ -1,0 +1,11 @@
+meta {
+  name: swagger
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{base_url}}:{{port}}/api/v1/swagger
+  body: none
+  auth: none
+}


### PR DESCRIPTION
The views and urls for the `login` and `signup` endpoints and serializer for the User model are now under the `User` app.

The API structure is refined as well. The root of all endpoints is `api/v1/` now. 
Here are the new endpoints:

- login: `{{base_url}}:{{port}}/api/v1/users/login`
- signup: `{{base_url}}:{{port}}/api/v1/users/signup`
- search: `{{base_url}}:{{port}}/api/v1/search/`
- swagger: `{{base_url}}:{{port}}/api/v1/swagger/`