### PR TITLE
feat(backend): return user-profile information together 

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -4,6 +4,41 @@ from .models import Post, Like, Bookmark, Follow, Profile
 
 
 class CreatePostSerializer(serializers.ModelSerializer):
+    like_count = serializers.SerializerMethodField()
+    bookmark_count = serializers.SerializerMethodField()
+    liked_by = serializers.SerializerMethodField()
+    is_liked = serializers.SerializerMethodField()
+    is_bookmarked = serializers.SerializerMethodField()
+    is_following = serializers.SerializerMethodField()
+
+
+    def get_like_count(self, obj):
+        return obj.like_set.count()
+
+    def get_bookmark_count(self, obj):
+        return obj.bookmark_set.count()
+    
+    def get_liked_by(self, obj):
+        likes = obj.like_set.all()
+        return [like.user.username for like in likes]
+    
+    def get_is_liked(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            return obj.like_set.filter(user=request.user).exists()
+        return False
+
+    def get_is_bookmarked(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            return obj.bookmark_set.filter(user=request.user).exists()
+        return False
+    
+    def get_is_following(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            return obj.author.followers.filter(follower=request.user).exists()
+        return False
 
     class Meta:
         model = Post

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -118,3 +118,14 @@ class ProfileSerializer(serializers.ModelSerializer):
         model = Profile
         read_only_fields = ["owner"]
         fields = '__all__'
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    picture = serializers.URLField(source="profile.picture", allow_null=True)
+    biography = serializers.CharField(source="profile.biography", allow_blank=True)
+    fullname = serializers.CharField(source="first_name", allow_blank=True)
+
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'fullname', 'picture', 'biography']
+    

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -3,7 +3,82 @@ from django.contrib.auth.models import User
 from .models import Post, Like, Bookmark, Follow, Profile
 
 
+class LikeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Like
+        read_only_fields = ['user']
+        fields = '__all__'
+
+
+class BookmarkSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Bookmark
+        read_only_fields = ['user']
+        fields = '__all__'
+
+
+class FollowSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Follow
+        read_only_fields = ['follower']
+        fields = '__all__'
+        read_only_fields = ['follower']
+
+
+class UserSerializer(serializers.ModelSerializer):
+    fullname = serializers.SerializerMethodField()
+
+    def get_fullname(self, obj):
+        return obj.first_name
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'fullname']
+
+
+class UserRegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+    fullname = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ['username', 'email', 'password', "fullname"]
+
+    def create(self, validated_data):
+        user = User.objects.create_user(
+            username=validated_data['username'],
+            email=validated_data['email'],
+            password=validated_data['password'],
+            first_name=validated_data['fullname'],
+        )
+        Profile.objects.create(owner=user)
+        return user
+
+class ProfileSerializer(serializers.ModelSerializer):
+    is_following = serializers.SerializerMethodField()
+    def get_is_following(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            return obj.owner.followers.filter(follower=request.user).exists()
+        return False
+    
+    class Meta:
+        model = Profile
+        read_only_fields = ["owner"]
+        fields = '__all__'
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    picture = serializers.URLField(source="profile.picture", allow_null=True)
+    biography = serializers.CharField(source="profile.biography", allow_blank=True)
+    fullname = serializers.CharField(source="first_name", allow_blank=True)
+
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'fullname', 'picture', 'biography']
+
+
 class CreatePostSerializer(serializers.ModelSerializer):
+    author_profile = UserProfileSerializer(source='author', read_only=True)
     like_count = serializers.SerializerMethodField()
     bookmark_count = serializers.SerializerMethodField()
     liked_by = serializers.SerializerMethodField()
@@ -89,78 +164,3 @@ class SearchPostSerializer(serializers.ModelSerializer):
         model = Post
         exclude = ['author']
         read_only_fields = ["username", "title", "content", "image_src", "qid", "qtitle", "created_at", "updated_at", "like_count", "bookmark_count", "liked_by", "is_liked", "is_bookmarked", "user_id", "is_following"]
-
-
-class LikeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Like
-        read_only_fields = ['user']
-        fields = '__all__'
-
-
-class BookmarkSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Bookmark
-        read_only_fields = ['user']
-        fields = '__all__'
-
-
-class FollowSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Follow
-        read_only_fields = ['follower']
-        fields = '__all__'
-        read_only_fields = ['follower']
-
-
-class UserSerializer(serializers.ModelSerializer):
-    fullname = serializers.SerializerMethodField()
-
-    def get_fullname(self, obj):
-        return obj.first_name
-    class Meta:
-        model = User
-        fields = ['id', 'username', 'email', 'fullname']
-
-
-class UserRegistrationSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(write_only=True)
-    fullname = serializers.CharField(write_only=True)
-
-    class Meta:
-        model = User
-        fields = ['username', 'email', 'password', "fullname"]
-
-    def create(self, validated_data):
-        user = User.objects.create_user(
-            username=validated_data['username'],
-            email=validated_data['email'],
-            password=validated_data['password'],
-            first_name=validated_data['fullname'],
-        )
-        Profile.objects.create(owner=user)
-        return user
-
-class ProfileSerializer(serializers.ModelSerializer):
-    is_following = serializers.SerializerMethodField()
-    def get_is_following(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            return obj.owner.followers.filter(follower=request.user).exists()
-        return False
-    
-    class Meta:
-        model = Profile
-        read_only_fields = ["owner"]
-        fields = '__all__'
-
-
-class UserProfileSerializer(serializers.ModelSerializer):
-    picture = serializers.URLField(source="profile.picture", allow_null=True)
-    biography = serializers.CharField(source="profile.biography", allow_blank=True)
-    fullname = serializers.CharField(source="first_name", allow_blank=True)
-
-    class Meta:
-        model = User
-        fields = ['id', 'username', 'email', 'fullname', 'picture', 'biography']
-    

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -39,4 +39,5 @@ urlpatterns = [
     ),
     path("login/", LoginView.as_view(), name="login"),
     path("info/", WikiInfoView.as_view(), name="info"),
+    path("user-profile/<str:username>/", UserProfileView.as_view(), name="user-profile"),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,8 +1,9 @@
 import requests
-from rest_framework import viewsets, permissions, status
+from rest_framework import viewsets, permissions, status, generics
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.exceptions import NotFound
 from django.contrib.auth.models import User
 from .models import Post, Like, Bookmark, Follow, Profile
 from .serializers import *
@@ -263,3 +264,16 @@ class WikiInfoView(APIView):
                 {"res": "An unexpected error occurred."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class UserProfileView(generics.RetrieveAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserProfileSerializer
+    lookup_field = 'username'
+
+    def get_object(self):
+        username = self.kwargs.get(self.lookup_field)
+        try:
+            return User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise NotFound(f'User with username "{username}" not found')


### PR DESCRIPTION
1. This PR updates the Post view to include user profile information in the response, as requested by the frontend team. 

The endpoint can be reached at `user-profile/<str:username>/`

2. On the fly calculated fields for the Post model, such as like_count, etc., was returned only in the search results only. Now, they are returned in other `posts/` endpoints as well.

3. The changes ensure that the combined User and Profile fields are returned along with the Post fields in a single endpoint.